### PR TITLE
replace django.conf.urls.url with django.urls.re_path

### DIFF
--- a/django_tequila/urls.py
+++ b/django_tequila/urls.py
@@ -2,12 +2,13 @@
     (c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2017
 """
 
-from django.conf.urls import url
+from django.urls import re_path
+
 
 from django_tequila.tequila_auth_views import login, logout, not_allowed
 
 urlpatterns = [
-    url(r'^login/?$', login, name='login_view'),
-    url(r'^logout/$', logout, name='logout'),
-    url(r'^not_allowed/$', not_allowed, name='not_allowed'),
+    re_path(r'^login/?$', login, name='login_view'),
+    re_path(r'^logout/$', logout, name='logout'),
+    re_path(r'^not_allowed/$', not_allowed, name='not_allowed'),
 ]


### PR DESCRIPTION
urls() was deprecated in Django 3.2 and removed in 4.0+, the latest LTS version is now 4.2 Also, re_path works as a direct replacement and was added around Django 2.2, so it should be perfectly safe to swap them here.