### PR TITLE
Correction for Django 4.2

### DIFF
--- a/django_tequila/tequila_auth_views/__init__.py
+++ b/django_tequila/tequila_auth_views/__init__.py
@@ -7,7 +7,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 
 from django.http import HttpResponse, HttpResponseRedirect
 from django.views.decorators.cache import never_cache
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.conf import settings
 
 from django_tequila.tequila_client import TequilaClient
@@ -22,7 +22,7 @@ def get_redirect_url(request):
     """Return the user-originating redirect URL if it's safe."""
     redirect_to = request.GET.get(REDIRECT_FIELD_NAME)
 
-    url_is_safe = is_safe_url(
+    url_is_safe = url_has_allowed_host_and_scheme(
         url=redirect_to,
         allowed_hosts=request.get_host(),
         require_https=request.is_secure(),

--- a/django_tequila/urls.py
+++ b/django_tequila/urls.py
@@ -2,12 +2,13 @@
     (c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2017
 """
 
-from django.conf.urls import url
+# from django.conf.urls import url
+from django.urls import re_path
 
 from django_tequila.tequila_auth_views import login, logout, not_allowed
 
 urlpatterns = [
-    url(r'^login/?$', login, name='login_view'),
-    url(r'^logout/$', logout, name='logout'),
-    url(r'^not_allowed/$', not_allowed, name='not_allowed'),
+    re_path(r'^login/?$', login, name='login_view'),
+    re_path(r'^logout/$', logout, name='logout'),
+    re_path(r'^not_allowed/$', not_allowed, name='not_allowed'),
 ]


### PR DESCRIPTION
https://docs.djangoproject.com/en/4.0/releases/3.0/#features-deprecated-in-3-0
Changed `is_safe_url` to `url_has_allowed_host_and_scheme`
---
https://docs.djangoproject.com/en/4.0/releases/3.0/#miscellaneous
Changed `url` to `re_path`

django-tequila is now compatible with Django 4.2+